### PR TITLE
Fix for ruby 2.3

### DIFF
--- a/ext/screen_recorder/extconf.rb
+++ b/ext/screen_recorder/extconf.rb
@@ -1,6 +1,6 @@
 require 'mkmf'
 
-$CFLAGS << ' -std=c99 -Wall -Werror -pedantic -ObjC'
+$CFLAGS << ' -Wall -Werror -pedantic -ObjC'
 $LIBS   << ' -framework AVFoundation -framework Cocoa'
 
 if RUBY_ENGINE == 'macruby'

--- a/screen_recorder.gemspec
+++ b/screen_recorder.gemspec
@@ -14,7 +14,7 @@ Originally extracted from the AXElements project.
   s.authors     = ['Mark Rada']
   s.email       = 'markrada26@gmail.com'
   s.homepage    = 'http://github.com/AXElements/screen_recorder'
-  s.licenses    = ['BSD 3-clause']
+  s.licenses    = ['BSD-3-Clause']
   s.has_rdoc    = 'yard'
 
   s.extensions  = ['ext/screen_recorder/extconf.rb']


### PR DESCRIPTION
c99 flags does not work with ruby 2.3; remove
fix license clause to be one of the standard ones
